### PR TITLE
Fix inlining when using a name other than glslify

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ var glslify = require('glslify-stream')
   , concat = require('concat-stream')
   , evaluate = require('static-eval')
   , extract = require('glsl-extract')
-  , first = require('first-match')
   , through = require('through')
   , resolve = require('resolve')
   , esprima = require('esprima')
@@ -33,7 +32,9 @@ function transform(filename) {
     // break out early if it doesn't look like
     // we're going to find any shaders here,
     // parsing and transforming the AST is expensive!
-    if(!usageRegex.test(buf)) return bail(buf)
+    if(!usageRegex.test(buf)) {
+      return bail(buf)
+    }
 
     var ast = esprima.parse(buf)
       , name = glslifyname(ast)
@@ -43,7 +44,9 @@ function transform(filename) {
       , id = 0
 
     // bail early if glslify isn't required at all
-    if(!name) return bail(buf)
+    if(!name) {
+      return bail(buf)
+    }
 
     src.replace([name], function(node) {
       var fragment
@@ -149,9 +152,11 @@ function transform(filename) {
 
 function glslifyname(ast) {
   var required = sleuth(ast)
-  var keys = Object.keys(required)
+  var name
 
-  return first(keys, function(key) {
-    return required[key] === 'glslify'
+  Object.keys(required).some(function(key) {
+    return name = (required[key] === 'glslify' ? key : null)
   })
+
+  return name
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "resolve": "^0.6.1",
     "concat-stream": "^1.4.1",
     "glsl-extract": "0.0.2",
-    "first-match": "0.0.1",
     "sleuth": "0.0.0",
     "esprima": "^1.0.4",
     "gl-shader-core": "^2.0.0"


### PR DESCRIPTION
Previously, glslify was assuming the variable name used for requiring would be "glslify". This would mean the following would not work:

``` javascript
var createShader = require('glslify')

createShader({
    vertex: './file.vert'
   , fragment: './file.frag'
})
```

And the following would still get replaced:

``` javascript
glslify('no requires')
```

Using the [sleuth](http://github.com/hughsk/sleuth) module makes it easy to discover what variable name is being used and use it with replace-method.

Have also included preemptive checks to bail before parsing files which definitely don't contain calls to "glslify" within.

@chrisdickinson let me know if you have any thoughts on this before I merge, if you have the time :)
