### PR TITLE
fixed bug with paths in included modules not resolving

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,9 +60,10 @@ function transform(filename) {
         return
       }
 
+      var cwd = path.dirname(filename)
       config = evaluate(node.arguments[0], {
           __filename: filename
-        , __dirname: path.dirname(filename)
+        , __dirname: cwd
       })
 
       if(typeof config !== 'object') {
@@ -70,11 +71,11 @@ function transform(filename) {
       }
 
       ++loading
-      glslify(config.vertex)
+      glslify(path.resolve(cwd, config.vertex))
         .pipe(deparser())
         .pipe(concat(onvertex))
 
-      glslify(config.fragment)
+      glslify(path.resolve(cwd, config.fragment))
         .pipe(deparser())
         .pipe(concat(onfragment))
 


### PR DESCRIPTION
Basically if you tried to use a module with a glslify transform as a dependency, then the current path resolution would fail.  This fix seems to solve the problem, though it would be good to get have someone more familiar with the code take a second look.

I am not sure if maybe something else needs to be done to handle dependency resolution for submodules.
