### PR TITLE
fixed regular expression bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var glslify = require('glslify-stream')
   , sleuth = require('sleuth')
   , path = require('path')
 
-var usageRegex = /['"]glslify['"]/g
+var usageRegex = /['"]glslify['"]/
 
 function transform(filename) {
   var stream = through(write, end)


### PR DESCRIPTION
Using `/g` for the regular expression prevents it from being used multiple times.  Since it doesn't seem like these semantics are needed I removed the qualifier.

Previously, running glslify on multiple modules would fail since it would only successfully match the first occurrence.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test
