### PR TITLE
Option to return source only for ThreeJS etc

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,6 +71,7 @@ function transform(filename) {
         return
       }
 
+      var sourceOnly = !!config.sourceOnly
       var frag = config.fragment || config.frag
       var vert = config.vertex || config.vert
       var inline = !!config.inline
@@ -111,7 +112,7 @@ function transform(filename) {
                 , name: 'require'
               }
             , arguments: [
-                  {type: 'Literal', value: 'glslify/adapter.js'}
+                  {type: 'Literal', value: sourceOnly ? 'glslify/simple-adapter.js' : 'glslify/adapter.js'}
               ]
           }
         , arguments: [

--- a/simple-adapter.js
+++ b/simple-adapter.js
@@ -1,0 +1,10 @@
+module.exports = programify
+
+function programify(vertex, fragment, uniforms, attributes) {
+  return {
+    vertex: vertex, 
+    fragment: fragment,
+    uniforms: uniforms, 
+    attributes: attributes
+  };
+}


### PR DESCRIPTION
see #11

Works like this:

``` js
var myShader = glslify({
    vertex: './vertex.glsl',
    fragment: './fragment.glsl',
    sourceOnly: true
});

//optionally do something with our uniforms/attribs
console.log( myShader.uniforms );

//setup custom ThreeJS material...
var mat = new THREE.ShaderMaterial({
    uniforms: { ... threejs uniforms ... },
    vertexShader: myShader.vertex,
    fragmentShader: myShader.fragment
});
```
