### PR TITLE
Convert tagged template example to function usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ with built in support for glslify.*
 
 ``` javascript
 var glsl = require('glslify')
-console.log(glsl`
+console.log(glsl(`
   #pragma glslify: noise = require('glsl-noise/simplex/3d')
 
   precision mediump float;
@@ -50,7 +50,7 @@ console.log(glsl`
   void main () {
     gl_FragColor = vec4(noise(vpos*25.0),1);
   }
-`)
+`))
 ```
 
 ## Module API
@@ -59,7 +59,7 @@ console.log(glsl`
 var glsl = require('glslify')
 ```
 
-### var src = `glsl\`shader source...\``
+### var src = ``glsl`shader source...` ``
 
 Compile a shader inline using `glsl` as a
 [tagged template string function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Tagged_template_literals).


### PR DESCRIPTION
This PR converts ``glsl`...` `` usage to ``glsl(`...`)`` due to #98 so that new users hopefully try the function usage first and avoid some potential problems, at least until that style is fixed.

Aiming for this as the lowest-hanging fruit, though I'd prefer to better understand how the tagged template *should* be used.