### PR TITLE
Upgrades package "static-eval" due to security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "minimist": "^1.2.0",
     "resolve": "^1.1.5",
     "stack-trace": "0.0.9",
-    "static-eval": "^1.1.1",
+    "static-eval": "^2.0.0",
     "tape": "^4.6.0",
     "through2": "^2.0.1",
     "xtend": "^4.0.0"


### PR DESCRIPTION
This PR upgrades the "static-eval" package from `1.1.1` to `2.0.0` to fix a Sandbox Breakout / Arbitrary Code Execution security vulnerability as reported on [Node Security](https://nodesecurity.io/check/glslify).

<img width="703" alt="screen shot 2017-11-07 at 14 27 37" src="https://user-images.githubusercontent.com/11870513/32495903-d067c74a-c3c7-11e7-8bff-ea0e0085fffc.png">
