### PR TITLE
fix DEP0013 warning with -o option

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -96,6 +96,6 @@ function output(err, tree) {
 
   function done() {
     if (!argv.output) return process.stdout.write(src)
-    fs.writeFile(argv.output, src)
+    fs.writeFileSync(argv.output, src)
   }
 }


### PR DESCRIPTION
Calling fs asynchronous functions without callbacks print out a warning message:
```
$ glslify shader.fsh -o build/shader.fsh
(node:78762) [DEP0013] DeprecationWarning: Calling an asynchronous function without callback is deprecated.
```
This cleans it up by using synchronized method when writing to output.