### PR TITLE
Support single line shaders

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,12 +6,13 @@ var extend        = require('xtend')
 var stackTrace    = require('stack-trace')
 
 module.exports = function(arg, opts) {
+  var isShaderString = /(void\s+main\s?\(.*\)|\n)/.test(arg)
   if (Array.isArray(arg)) { // template string
     return iface().tag.apply(null, arguments)
-  } else if (typeof arg === 'string' && !/\n/.test(arg) && opts && opts._flags) {
+  } else if (typeof arg === 'string' && !isShaderString && opts && opts._flags) {
     // browserify transform
     return require('./transform.js').apply(this, arguments)
-  } else if (typeof arg === 'string' && /\n/.test(arg)) { // source string
+  } else if (typeof arg === 'string' && isShaderString) { // source string
     return iface().compile(arg, opts)
   } else if (typeof arg === 'string') { // source file
     return iface().file(arg, opts)

--- a/test/node.js
+++ b/test/node.js
@@ -18,6 +18,12 @@ test('node string', function(t) {
   t.end()
 })
 
+test('node string with single line shader', function(t) {
+  var output = glx('void main () {}')
+  t.equal(output, '#define GLSLIFY 1\nvoid main () {}')
+  t.end()
+})
+
 test('node simulated tagged template string', function(t) {
   var output = glx([''
     +'  #pragma glslify: noise = require("glsl-noise/simplex/3d")\n'

--- a/transform.js
+++ b/transform.js
@@ -138,7 +138,7 @@ module.exports = function (file, opts) {
       var marg = evaluate(p.arguments[0])
       var mopts = p.arguments[1] ? evaluate(p.arguments[1]) || {} : {}
       var d = createDeps(extend({ cwd: mdir }, mopts))
-      if (/\n/.test(marg)) { // source string
+      if (/(void\s+main\s?\(.*\)|\n)/.test(marg)) { // source string
         d.inline(marg, mdir, ondeps)
       } else gresolve(marg, { basedir: mdir }, function (err, res) {
         if (err) d.emit('error', err)


### PR DESCRIPTION
Right now if you use browserify + source transform and `glslify('void main () {}')`, it gets treated as a file. With this change we will at least detect any source with `void main ()` in it, to catch most cases of shader strings.

Also had to fix one of the import tests since it was failing with new browserify versions.