### PR TITLE
Add support for ES7+

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "bl": "^1.0.0",
     "concat-stream": "^1.5.2",
     "duplexify": "^3.4.5",
-    "falafel": "^2.0.0",
+    "falafel": "^2.1.0",
     "from2": "^2.3.0",
     "glsl-resolve": "0.0.1",
     "glsl-token-whitespace-trim": "^1.0.0",
@@ -36,7 +36,7 @@
     "xtend": "^4.0.0"
   },
   "devDependencies": {
-    "browserify": "^12.0.1",
+    "browserify": "^16.2.2",
     "electron-prebuilt": "^1.3.3",
     "electron-spawn": "^5.0.0",
     "from2": "^2.3.0",

--- a/transform.js
+++ b/transform.js
@@ -14,7 +14,7 @@ var extend = require('xtend')
 var glslfile0 = path.join(__dirname,'index.js')
 var glslfile1 = path.join(__dirname,'index')
 var parseOptions = {
-  ecmaVersion: 6,
+  ecmaVersion: 10,
   sourceType: 'module',
   allowReturnOutsideFunction: true,
   allowImportExportEverywhere: true,


### PR DESCRIPTION
This will allow the transform not to break on code that includes things like:

- Async/await syntax
- Object rest spread syntax
- Future enhancements that are still in somewhat proposal stage

Since these things are already appearing in Chrome and other browsers, IMHO it's best to support them.

I will probably merge this in a day or so if nobody objects.