### PR TITLE
Fix some issue when enable `post` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,8 +73,12 @@ function iface () {
   function bundle (deps) {
     var source = glslifyBundle(deps)
     posts.forEach(function (tr) {
-      var target = nodeResolve.sync(tr.name, { basedir: basedir })
-      var transform = require(target)
+      if (typeof tr.name === 'function') {
+        var transform = tr.name
+      } else {
+        var target = nodeResolve.sync(tr.name, { basedir: basedir })
+        var transform = require(target)
+      }
       var src = transform(null, source, { post: true })
       if (src) source = src
     })

--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ function iface () {
         var target = nodeResolve.sync(tr.name, { basedir: basedir })
         var transform = require(target)
       }
-      var src = transform(null, source, { post: true })
+      var src = transform((deps && deps[0] && deps[0].file) || null, source, { post: true })
       if (src) source = src
     })
     return source

--- a/test/node.js
+++ b/test/node.js
@@ -53,3 +53,27 @@ if (supportsTTS) test('node tagged template string', function(t) {
   t.ok(/vpos\*25\.0\),1/.test(output), 'interpolated var')
   t.end()
 })
+
+test('test function transform with post option', function(t) {
+  var transform = function (file, src, opts, done) {
+    if (done) {
+      done(null, src);
+    } else {
+      return src;
+    }
+  }
+  var output = glx([
+    '  #pragma glslify: noise = require("glsl-noise/simplex/3d")',
+    '  precision mediump float;',
+    '  varying vec3 vpos;',
+    '  void main () {',
+    '    gl_FragColor = vec4(noise(vpos*25.0),1);',
+    '  }',
+  ].join('\n'), {
+    transform: [
+      [transform, { post: true }]
+    ]
+  })
+  t.ok(/taylorInvSqrt/.test(output), 'contains parts of the file')
+  t.end()
+})


### PR DESCRIPTION
I try to write a transform that used to do lint, so it should enable `post` option.
I noticed that pass a function transform instead of package name, glslify will throw a error, and the transform cannot get filename.
So this PR fixed the two issues, but this issue(https://github.com/glslify/glslify/issues/114) has still not been fixed in this PR.
