### PR TITLE
Pass file path to post transforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "resolve": "^1.1.5",
     "stack-trace": "0.0.9",
     "static-eval": "^2.0.0",
-    "tape": "^4.6.0",
     "through2": "^2.0.1",
     "xtend": "^4.0.0"
   },
@@ -39,13 +38,12 @@
     "browserify": "^16.2.2",
     "electron-prebuilt": "^1.3.3",
     "electron-spawn": "^5.0.0",
-    "from2": "^2.3.0",
     "glsl-easings": "^1.0.0",
     "glsl-noise": "0.0.0",
     "glslify-hex": "^2.0.1",
     "shell-quote": "^1.4.3",
     "tap-spec": "^2.2.1",
-    "tape": "^3.5.0",
+    "tape": "^4.6.0",
     "uniq": "^1.0.1"
   },
   "repository": {

--- a/test/fixtures/check-contents.js
+++ b/test/fixtures/check-contents.js
@@ -1,0 +1,13 @@
+module.exports = function (file, src, opts, done) {
+  for (var i = 0; i < opts.contents.length; i++) {
+    if (src.indexOf(opts.contents[i]) === -1) {
+      var err = new Error("File is missing: " + JSON.stringify(opts.contents[i]))
+      if (done) return done(err)
+      throw err
+    }
+  }
+
+  src = [src, '#define CHECK_CONTENTS 1'].join('\n\n')
+
+  return done ? done(null, src) : src
+}

--- a/test/fixtures/post-transform-check-child.glsl
+++ b/test/fixtures/post-transform-check-child.glsl
@@ -1,0 +1,4 @@
+#define CHECK_2
+
+void dummy () {}
+#pragma glslify: export(dummy)

--- a/test/fixtures/post-transform-check.glsl
+++ b/test/fixtures/post-transform-check.glsl
@@ -1,0 +1,6 @@
+#define CHECK_1
+
+#pragma glslify: x = require('./post-transform-check-child')
+
+void main () {
+}

--- a/test/fixtures/replace-with-file.js
+++ b/test/fixtures/replace-with-file.js
@@ -1,0 +1,4 @@
+module.exports = function (file, src, opts, done) {
+  file = file || 'null'
+  return done ? done(null, file) : file
+}

--- a/transform.js
+++ b/transform.js
@@ -4,7 +4,7 @@ var through = require('through2')
 var concat = require('concat-stream')
 var from = require('from2')
 var gdeps = require('glslify-deps')
-var gbundle = require('glslify-bundle')
+var glslBundle = require('glslify-bundle')
 var path = require('path')
 var seval = require('static-eval')
 var resolve = require('resolve')
@@ -24,7 +24,6 @@ var parseOptions = {
 module.exports = function (file, opts) {
   if (path.extname(file) == '.json') return through()
   if (!opts) opts = {}
-  var posts = []
   var dir = path.dirname(file)
   var glvar = null, mdir = dir
   var evars = {
@@ -33,8 +32,33 @@ module.exports = function (file, opts) {
     require: { resolve: resolve }
   }
 
+  var sharedPosts = []
+  var sharedTransforms = updateSharedTransforms()
+
   function evaluate (expr) {
     return seval(expr, evars)
+  }
+
+  function updateSharedTransforms () {
+    ;[]
+      .concat(opts.post || [])
+      .concat(opts.p || [])
+      .forEach(function (post) {
+        post = Array.isArray(post) ? post : [post]
+        var name = post[0]
+        var opts = post[1] || {}
+        sharedPosts.push({ name: name, opts: opts, base: process.cwd() })
+      })
+
+    return []
+      .concat(opts.transform || [])
+      .concat(opts.t || [])
+      .filter(function (tr) {
+        var name = tr[0]
+        var opts = tr[1] || {}
+        if (!opts.post) return true
+        sharedPosts.push({ name: name, opts: opts, base: process.cwd() })
+      })
   }
 
   var d = duplexify()
@@ -105,7 +129,7 @@ module.exports = function (file, opts) {
       var d = createDeps({ cwd: mdir })
       d.inline(shadersrc, mdir, function (err, deps) {
         if (err) return d.emit('error', err)
-        try { var bsrc = bundle(deps) }
+        try { var bsrc = applyPostTransforms(null, deps, {}) }
         catch (err) { return d.emit('error', err) }
         node.update(node.tag.source() + '('
           + JSON.stringify(bsrc.split('__GLX_PLACEHOLDER__'))
@@ -119,16 +143,17 @@ module.exports = function (file, opts) {
     function callexpr (p, cb) {
       var marg = evaluate(p.arguments[0])
       var mopts = p.arguments[1] ? evaluate(p.arguments[1]) || {} : {}
-      var d = createDeps(extend({ cwd: mdir }, mopts))
+      var d = createDeps({ cwd: mdir })
+      var resolved = null
       if (/(void\s+main\s?\(.*\)|\n)/.test(marg)) { // source string
         d.inline(marg, mdir, ondeps)
       } else gresolve(marg, { basedir: mdir }, function (err, res) {
         if (err) d.emit('error', err)
-        else d.add(res, ondeps)
+        else d.add(resolved = res, ondeps)
       })
       function ondeps (err, deps) {
         if (err) return d.emit('error', err)
-        try { var bsrc = bundle(deps) }
+        try { var bsrc = applyPostTransforms(resolved, deps, mopts) }
         catch (err) { return d.emit('error', err) }
         p.update(p.callee.source()+'(['+JSON.stringify(bsrc)+'])')
         cb()
@@ -141,43 +166,27 @@ module.exports = function (file, opts) {
       d.inline(mfile, mdir, ondeps)
       function ondeps (err, deps) {
         if (err) return d.emit('error', err)
-        try { var bsrc = bundle(deps) }
+        try { var bsrc = applyPostTransforms(null, deps, mopts) }
         catch (err) { return d.emit('error', err) }
         p.update(glvar + '([' + JSON.stringify(bsrc) + '])')
         cb()
       }
     }
-    function callfile (p, cb) {
-      var mfile = p.arguments[0].value
-      gresolve(mfile, { basedir: mdir }, function (err, res) {
-        if (err) return d.emit('error', err)
-        var mopts = p.arguments[1] ? evaluate(p.arguments[1]) || {} : {}
-        var d = createDeps(extend({ cwd: path.dirname(res) }, mopts))
-        d.add(res, ondeps)
-      })
-      function ondeps (err, deps) {
-        if (err) return d.emit('error', err)
-        try { var bsrc = bundle(deps) }
-        catch (err) { return d.emit('error', err) }
-        p.update(glvar + '([' + JSON.stringify(bsrc) + '])')
-        cb()
-      }
-    }
-    function rcallfile (p, cb) {
+    function callfile (p, glvar, cb) {
       var mfile = evaluate(p.arguments[0])
       gresolve(mfile, { basedir: mdir }, function (err, res) {
         if (err) return d.emit('error', err)
         var mopts = p.arguments[1] ? evaluate(p.arguments[1]) || {} : {}
-        var d = createDeps(extend({ cwd: path.dirname(res) }, mopts))
+        var d = createDeps({ cwd: path.dirname(res) })
         d.add(res, ondeps)
+        function ondeps (err, deps) {
+          if (err) return d.emit('error', err)
+          try { var bsrc = applyPostTransforms(res, deps, mopts) }
+          catch (err) { return d.emit('error', err) }
+          p.update(glvar + '([' + JSON.stringify(bsrc) + '])')
+          cb()
+        }
       })
-      function ondeps (err, deps) {
-        if (err) return d.emit('error', err)
-        try { var bsrc = bundle(deps) }
-        catch (err) { return d.emit('error', err) }
-        p.update(p.callee.object.source()+'(['+JSON.stringify(bsrc)+'])')
-        cb()
-      }
     }
     function rcallcompile (p, cb) {
       var marg = evaluate(p.arguments[0])
@@ -186,7 +195,7 @@ module.exports = function (file, opts) {
       d.inline(marg, mdir, ondeps)
       function ondeps (err, deps) {
         if (err) return d.emit('error', err)
-        try { var bsrc = bundle(deps) }
+        try { var bsrc = applyPostTransforms(null, deps, mopts) }
         catch (err) { return d.emit('error', err) }
         p.update(p.callee.object.source()+'(['+JSON.stringify(bsrc)+'])')
         cb()
@@ -203,26 +212,36 @@ module.exports = function (file, opts) {
 
   function createDeps (opts) {
     var depper = gdeps(opts)
-    var basedir = opts.cwd
     depper.on('error', function (err) { d.emit('error', err) })
     depper.on('file', function (file) { d.emit('file', file) })
-    var transforms = opts.transform || []
+    var transforms = sharedTransforms
     transforms = Array.isArray(transforms) ? transforms : [transforms]
     transforms.forEach(function(transform) {
       transform = Array.isArray(transform) ? transform : [transform]
       var name = transform[0]
       var opts = transform[1] || {}
-      if (opts.post) {
-        posts.push({ name: name, opts: opts, base: basedir })
-      } else {
-        depper.transform(name, opts)
+      if (!opts.post) {
+        depper.transform(name, extend({}, opts))
       }
     })
     return depper
   }
-  function bundle (deps) {
-    var source = gbundle(deps)
-    posts.forEach(function (tr) {
+
+  function applyPostTransforms (rootFile, deps, mopts) {
+    var source = glslBundle(deps)
+    var localPosts = [].concat(mopts.transform || []).concat(mopts.t || [])
+      .map(function (transform) {
+        transform = Array.isArray(transform) ? transform : [transform]
+        var name = transform[0]
+        var opts = transform[1] || {}
+        return opts.post && { name: name, opts: opts, base: path.dirname(rootFile) }
+      })
+      .filter(Boolean)
+
+    sharedPosts.forEach(applyPostTransform)
+    localPosts.forEach(applyPostTransform)
+
+    function applyPostTransform (tr) {
       var transform
       if (typeof tr.name === "function") {
         transform = tr.name


### PR DESCRIPTION
This was previously null, as the final output isn't technically a single file in most cases. However, it
can still be useful to have access to the entry file as is the case with [glslify-lint](https://github.com/Eronana/glslify-lint).

Also fixed some tests which were generating false positives and added some new ones to catch edge cases. Post transforms should now work everywhere you'd expect them to — as it turns out glslify was ignoring them in a bunch of cases, while also doubling up on post transforms in others.

This will be a major version bump, but I suspect it won't have a huge impact as post transforms haven't been used a much in the wild afaik.