### PR TITLE
Fix "TypeError: Cannot read property 'emit' of undefined"

### DIFF
--- a/transform.js
+++ b/transform.js
@@ -168,8 +168,8 @@ module.exports = function (file, opts) {
     function callcompile (p, glvar, cb) {
       var mfile = evaluate(p.arguments[0])
       var mopts = p.arguments[1] ? evaluate(p.arguments[1]) || {} : {}
-      var d = createDeps({ cwd: mdir })
-      d.inline(mfile, mdir, ondeps)
+      var depsObject = createDeps({ cwd: mdir })
+      depsObject.inline(mfile, mdir, ondeps)
       function ondeps (err, deps) {
         if (err) return d.emit('error', err)
         applyPostTransforms(null, deps, mopts, function (err, bsrc) {


### PR DESCRIPTION
The `var d` shadows the duplex stream in a parent scope, which when a path in GLSL fails to resolve, causes the code to call `.emit` on the wrong object. This renames the shadowing object so that error emits are correctly routed to the duplex stream.