### PR TITLE
bump minimist versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "glsl-token-whitespace-trim": "^1.0.0",
     "glslify-bundle": "^5.0.0",
     "glslify-deps": "^1.2.5",
-    "minimist": "^1.2.0",
+    "minimist": "^1.2.5",
     "resolve": "^1.1.5",
     "stack-trace": "0.0.9",
     "static-eval": "^2.0.5",


### PR DESCRIPTION
Addressing https://www.npmjs.com/advisories/1179
@rreusser 

![minimist-tree](https://user-images.githubusercontent.com/33888540/90448611-b6de2100-e0b3-11ea-9954-f941ebeb6fff.png)

`tape-parser` uses v0.2.1 which is fine.

