### PR TITLE
Major dependency bumps without breaking node v4 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   ],
   "dependencies": {
     "bl": "^1.0.1",
-    "concat-stream": "^1.5.2",
-    "duplexify": "^3.4.5",
+    "concat-stream": "^2.0.0",
+    "duplexify": "^4.0.0",
     "falafel": "^2.1.0",
     "from2": "^2.3.0",
     "glsl-resolve": "0.0.1",
@@ -31,7 +31,7 @@
     "resolve": "^1.1.5",
     "stack-trace": "0.0.9",
     "static-eval": "^2.0.5",
-    "through2": "^2.0.1",
+    "through2": "^3.0.0",
     "xtend": "^4.0.0"
   },
   "devDependencies": {
@@ -42,8 +42,8 @@
     "glsl-noise": "0.0.0",
     "glslify-hex": "^2.0.1",
     "shell-quote": "^1.6.1",
-    "tap-spec": "^2.2.1",
-    "tape": "^4.6.0",
+    "tap-spec": "^5.0.0",
+    "tape": "^5.0.0",
     "uniq": "^1.0.1"
   },
   "repository": {


### PR DESCRIPTION
Attempt major bumps (i.e. vX.0.0) for various dependencies without breaking `node v4` support.
Caution: this PR may require additional testing.

@rreusser 
